### PR TITLE
finaler Layer im Dockerfile auf Java Runtime umstellen und Ergänzung Dokumentation Podman/Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY src ./src
 # Build the application using Maven
 RUN mvn clean package
 # Use an official OpenJDK image as the base image
-FROM openjdk:21-jdk-slim
+FROM eclipse-temurin:21-jre
 # Set the working directory in the container
 WORKDIR /app
 # Copy the built JAR file from the previous stage to the container

--- a/README.md
+++ b/README.md
@@ -79,7 +79,17 @@ Formpost wird an den Keycloak zurückgeleitet. Dort werden die Userdaten verarbe
 
 Aufruf der lokalen Anwendung:
 
-    http://localhost:8443/saml
+http://localhost:8080/saml
+
+
+## Lokales Ausführen mit Docker/Podman
+- Zuerst das Docker Image  mit `podman build -t bundid-simulator -f Dockerfile .` bauen.
+Dann kann der `BundID Simulator` wie folgt gestartet werden:
+```
+podman run --rm -it -p 8080:8080 bundid-simulator
+```
+Wenn `Docker` verwendet wird, muss in den obigen Befehlen `podman` durch `docker` ersetzt werden.
+
 
 ## Architektur
 


### PR DESCRIPTION
Im letzten Layer des Dockerfiles wird ein JDK Image als Basis benutzt. Das sollte in diesem Layer nicht notwendig sein,  da dort bereits ein gebautes Jar vorliegt und somit kein Java Compiler benötigt wird.

Da im 1. Layer zum Bauen Eclipse Temurin benutzt wurde, wurde die Eclipse Temurin Java **Runtime** als Basis-Image für den finalen Layer ausgewählt

Ich habe ebenfalls in der Readme.MD eine Sektion eingeführt, in der das Bauen und Ausführen mit Podman beschreiben wird.